### PR TITLE
Add lesson flow and Palestine-themed content

### DIFF
--- a/Advanced Listening
+++ b/Advanced Listening
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1.0" />
-<title>Listening Activity: The Future of Space</title>
+<title>Listening Activity: Life in Palestine</title>
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link href="https://fonts.googleapis.com/css2?family=Questrial&family=Nunito:ital,wght@0,400;0,600;0,700;1,400&display=swap" rel="stylesheet" />
@@ -215,11 +215,11 @@ h3.section-title {
 </head>
 <body>
   <div id="app-wrapper">
-    <div id="activity-container" data-query-theme="Artemis mission moon exploration">
+    <div id="activity-container" data-query-theme="Palestinian daily life">
       <div id="activity-header">
         <div id="activity-titles">
-          <h1 id="episode-title">NASA's Curious Universe</h1>
-          <h2 class="rubric" id="episode-rubric">Listen to this segment on the future of lunar exploration.</h2>
+          <h1 id="episode-title">Voices from Palestine</h1>
+          <h2 class="rubric" id="episode-rubric">Listen to this segment about daily life in Palestine.</h2>
         </div>
         <div id="decorative-image-container">
           <div class="placeholder-loader"></div>
@@ -326,7 +326,7 @@ h3.section-title {
       // !!! INSECURE - FOR DEMO ONLY. API KEY IS EXPOSED.
       API_KEY: "e015e88b576742a19718aebab2bc4465",
       TRANSCRIPT_ID: null,
-      KEYWORDS: ['Artemis', 'Moon', 'lunar', 'astronauts', 'habitats', 'space', 'mission', 'surface', 'explore', 'Mars'],
+      KEYWORDS: ['Palestine', 'Gaza', 'West Bank', 'Jerusalem', 'Ramallah', 'heritage', 'olive', 'culture', 'tradition', 'community'],
 
       init(audioUrl) {
         const container = document.getElementById('gap-fill-container');

--- a/Dropdown
+++ b/Dropdown
@@ -170,11 +170,11 @@
 <body>
 
   <div id="app-wrapper">
-    <div id="activity-container" data-query-theme="rome colosseum senate ancient">
+    <div id="activity-container" data-query-theme="Palestinian culture daily life">
 
       <div id="activity-header">
         <div id="activity-titles">
-          <h1>The Roman Empire</h1>
+          <h1>Life in Palestine</h1>
           <h2 class="rubric">Fill in the gaps to complete the sentences.</h2>
         </div>
         <div id="decorative-image-container">
@@ -184,55 +184,58 @@
 
       <div class="gapfill-container">
         <p>
-          The famous amphitheater in the center of the city, known for its gladiator contests, is called the
+          The city in the West Bank known for its bustling markets is the
           <span class="gap-wrapper"
-                data-feedback-title="The famous amphitheater..."
-                data-correct-answer="Colosseum"
-                data-explanation="The Colosseum was the largest amphitheater ever built and was used for gladiatorial contests and public spectacles.">
+                data-feedback-title="City of lively markets"
+                data-correct-answer="Nablus"
+                data-explanation="Nablus is famed for its historic markets and sweet Kanafeh."
+          >
             <select>
               <option value="">Select...</option>
-              <option value="Colosseum">Colosseum</option>
-              <option value="Pantheon">Pantheon</option>
-              <option value="Forum">Forum</option>
+              <option value="Hebron">Hebron</option>
+              <option value="Nablus">Nablus</option>
+              <option value="Jericho">Jericho</option>
             </select>
           </span>.
-          The governing and advisory assembly of the aristocracy in the ancient Roman Republic was the
+          A traditional Palestinian scarf is the
           <span class="gap-wrapper"
-                data-feedback-title="The governing assembly..."
-                data-correct-answer="Senate"
-                data-explanation="The Senate was a permanent and powerful institution in the Roman government, composed of the most prominent men in Rome.">
+                data-feedback-title="Traditional scarf"
+                data-correct-answer="keffiyeh"
+                data-explanation="The black-and-white keffiyeh is a symbol of Palestinian heritage."
+          >
             <select>
               <option value="">Select...</option>
-              <option value="Assembly">Assembly</option>
-              <option value="Senate">Senate</option>
-              <option value="Council">Council</option>
+              <option value="keffiyeh">keffiyeh</option>
+              <option value="shemagh">shemagh</option>
+              <option value="abaya">abaya</option>
             </select>
           </span>.
-          A
+          The salty lake bordering Jordan and Palestine is the
           <span class="gap-wrapper"
-                data-feedback-title="A ... was the largest unit of the Roman army"
-                data-correct-answer="legion"
-                data-explanation="The legion was the backbone of the Roman military machine, known for its discipline and effectiveness in battle.">
+                data-feedback-title="Salty lake"
+                data-correct-answer="Dead Sea"
+                data-explanation="The Dead Sea is renowned for its hypersaline water and mineral-rich mud."
+          >
             <select>
               <option value="">Select...</option>
-              <option value="battalion">battalion</option>
-              <option value="phalanx">phalanx</option>
-              <option value="legion">legion</option>
+              <option value="Dead Sea">Dead Sea</option>
+              <option value="Red Sea">Red Sea</option>
+              <option value="Lake Tiberias">Lake Tiberias</option>
             </select>
-          </span>
-          was the largest unit of the Roman army. According to legend, the city of
+          </span>.
+          Every autumn, many Palestinian farmers harvest
           <span class="gap-wrapper"
-                data-feedback-title="The city of ... was founded by twins"
-                data-correct-answer="Rome"
-                data-explanation="The founding myth of Rome, involving twin brothers Romulus and Remus, is a cornerstone of Roman culture and history.">
+                data-feedback-title="Autumn harvest"
+                data-correct-answer="olives"
+                data-explanation="Olive picking season is a central part of Palestinian agricultural life."
+          >
             <select>
               <option value="">Select...</option>
-              <option value="Athens">Athens</option>
-              <option value="Carthage">Carthage</option>
-              <option value="Rome">Rome</option>
+              <option value="oranges">oranges</option>
+              <option value="olives">olives</option>
+              <option value="apples">apples</option>
             </select>
-          </span>
-          was founded by the twin brothers Romulus and Remus in 753 BC.
+          </span>.
         </p>
       </div>
 

--- a/Grouping
+++ b/Grouping
@@ -157,14 +157,14 @@
   
   <div id="app-wrapper">
     <!-- The key change is here: data-activity-type tells the JS which mode to use. -->
-    <div id="activity-container" 
-         data-activity-type="single-image" 
-         data-query-theme="books library abstract">
+    <div id="activity-container"
+         data-activity-type="single-image"
+         data-query-theme="Palestinian culture">
       
       <div id="activity-header">
         <div id="activity-titles">
-          <h1>Discourse Markers</h1>
-          <h2 class="rubric">Categorise these linking words by their function.</h2>
+          <h1>Palestinian Culture</h1>
+          <h2 class="rubric">Drag each item to its correct category.</h2>
         </div>
         <div id="decorative-image-container">
           <div class="placeholder-loader"></div>
@@ -174,22 +174,22 @@
       <div class="dnd-main-container">
         <!-- Pool of items to drag -->
         <div id="items-pool-container">
-          <h3>Linking Words</h3>
+          <h3>Word Bank</h3>
           <div id="items-pool" class="dnd-list">
-            <div class="dnd-item" data-correct-category="contrast" data-explanation="'However' is used to introduce a statement that contrasts with or seems to contradict something that has been said previously.">However</div>
-            <div class="dnd-item" data-correct-category="addition" data-explanation="'Furthermore' adds another piece of information to the point you are making.">Furthermore</div>
-            <div class="dnd-item" data-correct-category="consequence" data-explanation="'Therefore' indicates that a statement is the logical consequence of the one that came before it.">Therefore</div>
-            <div class="dnd-item" data-correct-category="contrast" data-explanation="'On the other hand' is used to present a contrasting point of view.">On the other hand</div>
-            <div class="dnd-item" data-correct-category="consequence" data-explanation="'As a result' shows that the second statement is a result of the first.">As a result</div>
-            <div class="dnd-item" data-correct-category="addition" data-explanation="'Moreover' is used to introduce a piece of information that adds to or supports the previous one.">Moreover</div>
+            <div class="dnd-item" data-correct-category="addition" data-explanation="Nablus is a northern West Bank city famous for its bustling markets and sweets like kanafeh.">Nablus</div>
+            <div class="dnd-item" data-correct-category="addition" data-explanation="Hebron is known for its old city and traditional glass blowing workshops.">Hebron</div>
+            <div class="dnd-item" data-correct-category="contrast" data-explanation="The Dome of the Rock is an iconic golden shrine in Jerusalem." >Dome of the Rock</div>
+            <div class="dnd-item" data-correct-category="contrast" data-explanation="The Church of the Nativity in Bethlehem marks the traditional birthplace of Jesus." >Church of the Nativity</div>
+            <div class="dnd-item" data-correct-category="consequence" data-explanation="Kanafeh is a sweet cheese pastry soaked in syrup, enjoyed across Palestine." >Kanafeh</div>
+            <div class="dnd-item" data-correct-category="consequence" data-explanation="Maqluba is a layered rice dish with meat and vegetables flipped onto a serving tray." >Maqluba</div>
           </div>
         </div>
         
         <!-- Category Drop Zones -->
         <div id="category-zones">
-          <div id="addition" class="dnd-category-zone"><h3>Addition</h3><div class="dnd-list"></div></div>
-          <div id="contrast" class="dnd-category-zone"><h3>Contrast</h3><div class="dnd-list"></div></div>
-          <div id="consequence" class="dnd-category-zone"><h3>Consequence</h3><div class="dnd-list"></div></div>
+          <div id="addition" class="dnd-category-zone"><h3>Cities</h3><div class="dnd-list"></div></div>
+          <div id="contrast" class="dnd-category-zone"><h3>Landmarks</h3><div class="dnd-list"></div></div>
+          <div id="consequence" class="dnd-category-zone"><h3>Foods</h3><div class="dnd-list"></div></div>
         </div>
       </div>
       

--- a/Image labelling
+++ b/Image labelling
@@ -291,49 +291,49 @@
   
   <div id="app-wrapper">
     <div id="activity-container">
-      <h1>Mediterranean Flora</h1>
-      <h2 class="rubric">Drag the labels from the word bank to the correct plant images.</h2>
+      <h1>Scenes of Palestine</h1>
+      <h2 class="rubric">Drag the labels from the word bank to match each image.</h2>
       
       <div class="image-labelling-grid">
         <div class="image-labelling-card">
-          <img data-query="olive tree branch fruit" alt="A photo of an olive branch." src="">
-          <div class="image-labelling-dropzone" data-match="Olive"></div>
-          <div class="explanation" style="display: none;">The olive is a cornerstone of Mediterranean agriculture, prized for its fruit and the oil extracted from it. It thrives in hot, dry climates.</div>
+          <img data-query="palestinian olive harvest" alt="People harvesting olives." src="">
+          <div class="image-labelling-dropzone" data-match="Olive harvest"></div>
+          <div class="explanation" style="display: none;">Olive picking is an annual tradition that brings families together across Palestine.</div>
         </div>
         <div class="image-labelling-card">
-          <img data-query="prickly pear cactus flower fruit" alt="A photo of a prickly pear cactus." src="">
-          <div class="image-labelling-dropzone" data-match="Prickly pear cactus"></div>
-          <div class="explanation" style="display: none;">Also known as Opuntia, this cactus is recognized by its flat, fleshy pads. It produces colorful flowers and edible, spiny fruits.</div>
+          <img data-query="dabke dance" alt="A group performing dabke." src="">
+          <div class="image-labelling-dropzone" data-match="Dabke"></div>
+          <div class="explanation" style="display: none;">Dabke is a lively folk dance performed at celebrations and weddings.</div>
         </div>
         <div class="image-labelling-card">
-          <img data-query="red poppy flower field" alt="A photo of red poppies." src="">
-          <div class="image-labelling-dropzone" data-match="Poppies"></div>
-          <div class="explanation" style="display: none;">These vibrant red flowers are a common sight in Mediterranean fields and meadows, symbolizing remembrance and peace.</div>
+          <img data-query="al aqsa mosque jerusalem" alt="The Dome of the Rock." src="">
+          <div class="image-labelling-dropzone" data-match="Al Aqsa Mosque"></div>
+          <div class="explanation" style="display: none;">Located in Jerusalem, Al Aqsa Mosque is one of the holiest sites in Islam.</div>
         </div>
         <div class="image-labelling-card">
-          <img data-query="orange fruit tree branch" alt="A photo of oranges on a tree." src="">
-          <div class="image-labelling-dropzone" data-match="Oranges"></div>
-          <div class="explanation" style="display: none;">Citrus trees, especially oranges, are widely cultivated in the Mediterranean. Their sweet, juicy fruits are a major export.</div>
+          <img data-query="palestinian embroidery" alt="Traditional embroidery." src="">
+          <div class="image-labelling-dropzone" data-match="Embroidery"></div>
+          <div class="explanation" style="display: none;">Colorful stitched patterns are a proud expression of Palestinian heritage.</div>
         </div>
         <div class="image-labelling-card">
-          <img data-query="italian cypress tree landscape" alt="A photo of cypress trees." src="">
-          <div class="image-labelling-dropzone" data-match="Cypress"></div>
-          <div class="explanation" style="display: none;">The tall, slender, and dark green Italian Cypress is a classic feature of the Tuscan and broader Mediterranean landscape.</div>
+          <img data-query="falafel pita" alt="Falafel served in pita." src="">
+          <div class="image-labelling-dropzone" data-match="Falafel"></div>
+          <div class="explanation" style="display: none;">Falafel, made from chickpeas or fava beans, is a beloved street food.</div>
         </div>
         <div class="image-labelling-card">
-          <img data-query="thyme herb plant garden" alt="A photo of a thyme plant." src="">
-          <div class="image-labelling-dropzone" data-match="Thyme"></div>
-          <div class="explanation" style="display: none;">This aromatic herb is native to the Mediterranean region and is a fundamental ingredient in its cuisine, known for its earthy flavor.</div>
+          <img data-query="dead sea float" alt="Floating in the Dead Sea." src="">
+          <div class="image-labelling-dropzone" data-match="Dead Sea"></div>
+          <div class="explanation" style="display: none;">Visitors can easily float in the Dead Sea due to its high salt content.</div>
         </div>
       </div>
 
       <div class="image-labelling-label-bank">
-        <div class="draggable-label" draggable="true">Cypress</div>
-        <div class="draggable-label" draggable="true">Poppies</div>
-        <div class="draggable-label" draggable="true">Thyme</div>
-        <div class="draggable-label" draggable="true">Olive</div>
-        <div class="draggable-label" draggable="true">Oranges</div>
-        <div class="draggable-label" draggable="true">Prickly pear cactus</div>
+        <div class="draggable-label" draggable="true">Embroidery</div>
+        <div class="draggable-label" draggable="true">Falafel</div>
+        <div class="draggable-label" draggable="true">Dabke</div>
+        <div class="draggable-label" draggable="true">Olive harvest</div>
+        <div class="draggable-label" draggable="true">Dead Sea</div>
+        <div class="draggable-label" draggable="true">Al Aqsa Mosque</div>
       </div>
 
       <div class="student-controls">

--- a/Linking
+++ b/Linking
@@ -307,18 +307,18 @@
 <body>
   
 <div id="app-wrapper">
-    <div id="activity-container" 
-         data-query-theme="synonyms antonyms vocabulary"
+    <div id="activity-container"
+         data-query-theme="Palestinian terms"
          data-answer-key='[
-            {"start": "L1", "end": "R3"},
-            {"start": "L2", "end": "R1"},
-            {"start": "L3", "end": "R2"}
+            {"start": "L1", "end": "R2"},
+            {"start": "L2", "end": "R3"},
+            {"start": "L3", "end": "R1"}
          ]'>
         
         <div id="activity-header">
             <div id="activity-titles">
-                <h1>Vocabulary Matching</h1>
-                <h2 class="rubric">Match each word to its correct synonym.</h2>
+                <h1>Palestinian Terms</h1>
+                <h2 class="rubric">Connect each word to its meaning.</h2>
             </div>
             <div id="decorative-image-container">
                 <div class="placeholder-loader"></div>
@@ -329,24 +329,24 @@
             <div class="linking-container">
                 <canvas class="linking-canvas"></canvas>
                 <div class="link-column left">
-                    <div class="linking-item" data-link-id="L1" data-explanation="'Ubiquitous' means present, appearing, or found everywhere, which is a direct synonym for 'omnipresent'.">
-                        <div class="linking-item-text">Ubiquitous</div>
-                        <div class="linking-item-connector"></div>
+                    <div class="linking-item" data-link-id="L1" data-explanation="'Al Quds' is the Arabic name widely used for the city of Jerusalem.">
+                        <div class="linking-item-text">Al Quds</div>
+                    <div class="linking-item-connector"></div>
                     </div>
-                    <div class="linking-item" data-link-id="L2" data-explanation="'Ephemeral' describes something that lasts for a very short time, which is synonymous with 'fleeting'.">
-                        <div class="linking-item-text">Ephemeral</div>
-                        <div class="linking-item-connector"></div>
+                    <div class="linking-item" data-link-id="L2" data-explanation="Kanafeh is a beloved Palestinian dessert of sweet cheese and syrup.">
+                        <div class="linking-item-text">Kanafeh</div>
+                    <div class="linking-item-connector"></div>
                     </div>
-                    <div class="linking-item" data-link-id="L3" data-explanation="'Malleable' means easily influenced or pliable, making it a synonym for 'impressionable'.">
-                        <div class="linking-item-text">Malleable</div>
-                        <div class="linking-item-connector"></div>
+                    <div class="linking-item" data-link-id="L3" data-explanation="Dabke is a traditional folk dance performed at celebrations.">
+                        <div class="linking-item-text">Dabke</div>
+                    <div class="linking-item-connector"></div>
                     </div>
                 </div>
 
                 <div class="link-column right">
-                    <div class="linking-item" data-link-id="R1"><div class="linking-item-text">Fleeting</div><div class="linking-item-connector"></div></div>
-                    <div class="linking-item" data-link-id="R2"><div class="linking-item-text">Impressionable</div><div class="linking-item-connector"></div></div>
-                    <div class="linking-item" data-link-id="R3"><div class="linking-item-text">Omnipresent</div><div class="linking-item-connector"></div></div>
+                    <div class="linking-item" data-link-id="R1"><div class="linking-item-text">Traditional dance</div><div class="linking-item-connector"></div></div>
+                    <div class="linking-item" data-link-id="R2"><div class="linking-item-text">Jerusalem</div><div class="linking-item-connector"></div></div>
+                    <div class="linking-item" data-link-id="R3"><div class="linking-item-text">Sweet cheese dessert</div><div class="linking-item-connector"></div></div>
                 </div>
                 
                 <div class="linking-controls">

--- a/Multiple Choice
+++ b/Multiple Choice
@@ -299,65 +299,65 @@
         <!-- Question 1: Single Choice -->
         <div class="mc-question">
           <div class="mc-question-header">
-            <div class="mc-question-text">What is the capital of France?</div>
+            <div class="mc-question-text">Which city is home to the Dome of the Rock?</div>
           </div>
           <div class="mc-options-container">
-            <div class="mc-option-item" data-correct="false">
-              <label class="mc-option-label">
-                <input type="radio" name="q1">
-                <span class="option-control"></span>
-                <span class="mc-option-text">Berlin</span>
-              </label>
-            </div>
             <div class="mc-option-item" data-correct="true">
               <label class="mc-option-label">
                 <input type="radio" name="q1">
                 <span class="option-control"></span>
-                <span class="mc-option-text">Paris</span>
+                <span class="mc-option-text">Jerusalem</span>
               </label>
             </div>
             <div class="mc-option-item" data-correct="false">
               <label class="mc-option-label">
                 <input type="radio" name="q1">
                 <span class="option-control"></span>
-                <span class="mc-option-text">London</span>
+                <span class="mc-option-text">Bethlehem</span>
+              </label>
+            </div>
+            <div class="mc-option-item" data-correct="false">
+              <label class="mc-option-label">
+                <input type="radio" name="q1">
+                <span class="option-control"></span>
+                <span class="mc-option-text">Gaza City</span>
               </label>
             </div>
           </div>
           <div class="mc-explanation" style="display: none;">
-            Paris is the capital and most populous city of France. It has been a major center of finance, diplomacy, commerce, fashion, gastronomy, science, and the arts for centuries.
+            The Dome of the Rock is located in Jerusalem's Old City.
           </div>
         </div>
         <!-- Question 2: Multiple Choice -->
         <div class="mc-question">
           <div class="mc-question-header">
-              <div class="mc-question-text">Which of the following are primary colors?</div>
+              <div class="mc-question-text">Which of the following foods are staples of Palestinian cuisine?</div>
           </div>
           <div class="mc-options-container">
               <div class="mc-option-item" data-correct="true">
                   <label class="mc-option-label">
                       <input type="checkbox" name="q2">
                       <span class="option-control"></span>
-                      <span class="mc-option-text">Red</span>
+                      <span class="mc-option-text">Maqluba</span>
                   </label>
               </div>
               <div class="mc-option-item" data-correct="false">
                   <label class="mc-option-label">
                       <input type="checkbox" name="q2">
                       <span class="option-control"></span>
-                      <span class="mc-option-text">Green</span>
+                      <span class="mc-option-text">Sushi</span>
                   </label>
               </div>
               <div class="mc-option-item" data-correct="true">
                   <label class="mc-option-label">
                       <input type="checkbox" name="q2">
                       <span class="option-control"></span>
-                      <span class="mc-option-text">Blue</span>
+                      <span class="mc-option-text">Falafel</span>
                   </label>
               </div>
           </div>
            <div class="mc-explanation" style="display: none;">
-            In the traditional RYB color model, the primary colors are Red, Yellow, and Blue. In the RGB model used for screens, they are Red, Green, and Blue. In this context, Red and Blue are correct.
+            Maqluba and falafel are common dishes enjoyed throughout Palestine.
           </div>
         </div>
       </div>

--- a/Multiple Choice Grid
+++ b/Multiple Choice Grid
@@ -419,12 +419,12 @@
 <body>
 
   <div id="app-wrapper">
-    <div id="activity-container" data-query-theme="science laboratory abstract">
+    <div id="activity-container" data-query-theme="Palestinian cities">
 
       <div id="activity-header">
         <div id="activity-titles">
-          <h1>States of Matter</h1>
-          <h2 class="rubric">Match each state of matter to its physical description.</h2>
+          <h1>Palestinian Cities</h1>
+          <h2 class="rubric">Match each city to its well-known feature.</h2>
         </div>
         <div id="decorative-image-container">
           <div class="placeholder-loader"></div>
@@ -436,36 +436,36 @@
           <thead>
             <tr>
               <th><!-- Empty corner --></th>
-              <th>Definite Shape & Volume</th>
-              <th>Definite Volume</th>
-              <th>Indefinite Shape & Volume</th>
-              <th>Ionized Gas</th>
+              <th>Home to Al Aqsa Mosque</th>
+              <th>On the Mediterranean coast</th>
+              <th>Famous for kanafeh</th>
+              <th>Site of the Nativity</th>
             </tr>
           </thead>
           <tbody>
-            <tr data-correct-column="col-1" data-explanation="A solid's particles are tightly packed in a fixed structure, giving it a definite shape and volume.">
-              <th scope="row">Solid</th>
+            <tr data-correct-column="col-1" data-explanation="Jerusalem is revered for the Al Aqsa Mosque within its Old City.">
+              <th scope="row">Jerusalem</th>
               <td><label><input type="radio" name="row-1" value="col-1"><span class="radio-custom"></span></label></td>
               <td><label><input type="radio" name="row-1" value="col-2"><span class="radio-custom"></span></label></td>
               <td><label><input type="radio" name="row-1" value="col-3"><span class="radio-custom"></span></label></td>
               <td><label><input type="radio" name="row-1" value="col-4"><span class="radio-custom"></span></label></td>
             </tr>
-            <tr data-correct-column="col-2" data-explanation="A liquid's particles can slide past one another, allowing it to take the shape of its container, but its volume remains constant.">
-              <th scope="row">Liquid</th>
+            <tr data-correct-column="col-2" data-explanation="Gaza City lies along the coast of the Mediterranean Sea.">
+              <th scope="row">Gaza City</th>
               <td><label><input type="radio" name="row-2" value="col-1"><span class="radio-custom"></span></label></td>
               <td><label><input type="radio" name="row-2" value="col-2"><span class="radio-custom"></span></label></td>
               <td><label><input type="radio" name="row-2" value="col-3"><span class="radio-custom"></span></label></td>
               <td><label><input type="radio" name="row-2" value="col-4"><span class="radio-custom"></span></label></td>
             </tr>
-            <tr data-correct-column="col-3" data-explanation="A gas's particles are far apart and move randomly, allowing it to expand to fill any container, giving it an indefinite shape and volume.">
-              <th scope="row">Gas</th>
+            <tr data-correct-column="col-3" data-explanation="Nablus is renowned for its sweet kanafeh dessert.">
+              <th scope="row">Nablus</th>
               <td><label><input type="radio" name="row-3" value="col-1"><span class="radio-custom"></span></label></td>
               <td><label><input type="radio" name="row-3" value="col-2"><span class="radio-custom"></span></label></td>
               <td><label><input type="radio" name="row-3" value="col-3"><span class="radio-custom"></span></label></td>
               <td><label><input type="radio" name="row-3" value="col-4"><span class="radio-custom"></span></label></td>
             </tr>
-            <tr data-correct-column="col-4" data-explanation="Plasma is a superheated state of matter where atoms are stripped of their electrons, creating an ionized gas.">
-              <th scope="row">Plasma</th>
+            <tr data-correct-column="col-4" data-explanation="Bethlehem attracts visitors to the Church of the Nativity.">
+              <th scope="row">Bethlehem</th>
               <td><label><input type="radio" name="row-4" value="col-1"><span class="radio-custom"></span></label></td>
               <td><label><input type="radio" name="row-4" value="col-2"><span class="radio-custom"></span></label></td>
               <td><label><input type="radio" name="row-4" value="col-3"><span class="radio-custom"></span></label></td>

--- a/lesson.html
+++ b/lesson.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Lesson Flow: Life in Palestine</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 0; padding: 0; }
+    h1 { text-align: center; padding: 20px 0; }
+    iframe { width: 100%; height: 800px; border: none; margin-bottom: 40px; }
+  </style>
+</head>
+<body>
+  <h1>Life in Palestine - Lesson Flow</h1>
+  <iframe src="Advanced%20Listening" title="Listening Activity"></iframe>
+  <iframe src="Image%20labelling" title="Image Labelling"></iframe>
+  <iframe src="Multiple%20Choice" title="Multiple Choice"></iframe>
+  <iframe src="Dropdown" title="Gap Fill"></iframe>
+</body>
+</html>

--- a/ranking
+++ b/ranking
@@ -213,14 +213,14 @@
 <body>
 
   <div id="app-wrapper">
-    <div id="activity-container" 
-         data-activity-type="single-image" 
-         data-query-theme="writing desk paper pen">
+    <div id="activity-container"
+         data-activity-type="single-image"
+         data-query-theme="Palestinian cooking">
 
       <div id="activity-header">
         <div id="activity-titles">
-          <h1>The Writing Process</h1>
-          <h2 class="rubric">Arrange the stages of the writing process in the correct order, from first to last.</h2>
+          <h1>Making Maqluba</h1>
+          <h2 class="rubric">Arrange the steps to cook maqluba in order.</h2>
         </div>
         <div id="decorative-image-container">
           <div class="placeholder-loader"></div>
@@ -230,13 +230,13 @@
       <div class="dnd-main-container">
         <!-- Pool of items to drag -->
         <div id="items-pool-container">
-          <h3>Stages</h3>
+          <h3>Steps</h3>
           <div id="items-pool" class="dnd-list">
-            <div class="dnd-item" data-correct-rank="3" data-explanation="Revising is the third stage. Here, you review the content, organization, and clarity of your draft, making significant changes to improve the overall piece.">Revising</div>
-            <div class="dnd-item" data-correct-rank="1" data-explanation="Prewriting is the first step, where you brainstorm ideas, research, and outline your topic before you begin writing.">Prewriting</div>
-            <div class="dnd-item" data-correct-rank="5" data-explanation="Publishing is the final stage, where you share your polished work with its intended audience.">Publishing</div>
-            <div class="dnd-item" data-correct-rank="2" data-explanation="Drafting is the second stage. This is where you write the first version of your text, focusing on getting your ideas down on paper.">Drafting</div>
-            <div class="dnd-item" data-correct-rank="4" data-explanation="Editing & Proofreading is the fourth stage. After revising the big picture, you focus on correcting grammar, spelling, punctuation, and formatting errors.">Editing & Proofreading</div>
+            <div class="dnd-item" data-correct-rank="3" data-explanation="Layer the rice, meat and vegetables tightly in the cooking pot for the classic upside-down effect.">Layer ingredients</div>
+            <div class="dnd-item" data-correct-rank="1" data-explanation="Marinating the meat with spices sets the foundation for flavor.">Marinate meat</div>
+            <div class="dnd-item" data-correct-rank="5" data-explanation="When done, invert the pot onto a tray and garnish with nuts and parsley.">Flip and garnish</div>
+            <div class="dnd-item" data-correct-rank="2" data-explanation="Fry the vegetables until lightly browned before adding them to the pot.">Fry vegetables</div>
+            <div class="dnd-item" data-correct-rank="4" data-explanation="Let the dish simmer so the rice absorbs all the flavours.">Simmer until cooked</div>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- create `lesson.html` to showcase multiple activities sequentially
- retheme **Advanced Listening** with Palestine query and keywords
- retheme **Image labelling** with Palestinian cultural scenes
- retheme **Multiple Choice** questions about Palestine
- retheme **Dropdown** gap-fill text about Palestinian life
- retheme **Grouping**, **Linking**, **Multiple Choice Grid**, and **ranking** activities with Palestinian topics

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6866f220a0b08326ba3f6de36d8076af