### PR TITLE
Use Bing for CC image search

### DIFF
--- a/Advanced Listening
+++ b/Advanced Listening
@@ -294,23 +294,24 @@ h3.section-title {
       },
     };
 
-    /* Handles fetching a decorative image from Pexels */
+    /* Handles fetching a decorative image from Bing */
     const ImageFetcher = {
       API_KEY: "xgmzSrq1PBV9ELvW4mSlyq6vAf0k6qDrrMd1zIpLrIheWepQ32zN4iJk", // Insecure: For testing only
-      
+
       async initSingleImage() {
         const container = document.getElementById("decorative-image-container");
         const themeQuery = document.getElementById("activity-container").dataset.queryTheme;
         if (!container || !themeQuery) return;
-        const url = `https://api.pexels.com/v1/search?query=${encodeURIComponent(themeQuery)}&per_page=1&orientation=landscape`;
+        const keywords = themeQuery.trim().split(/\s+/).slice(0, 3).join(" ");
+        const url = `https://api.bing.microsoft.com/v7.0/images/search?q=${encodeURIComponent(keywords)}&count=1&license=public&safeSearch=Strict`;
         try {
-          const response = await fetch(url, { headers: { Authorization: this.API_KEY } });
-          if (!response.ok) throw new Error("Pexels API glitch: " + response.statusText);
+          const response = await fetch(url, { headers: { "Ocp-Apim-Subscription-Key": this.API_KEY } });
+          if (!response.ok) throw new Error("Bing API error: " + response.statusText);
           const data = await response.json();
-          if (data.photos[0]) {
+          if (data.value && data.value[0]) {
             const img = document.createElement("img");
-            img.src = data.photos[0].src.landscape;
-            img.alt = data.photos[0].alt || `Decorative image for ${themeQuery}`;
+            img.src = data.value[0].contentUrl;
+            img.alt = data.value[0].name || `Decorative image for ${keywords}`;
             container.innerHTML = "";
             container.appendChild(img);
           } else { container.innerHTML = "?"; }

--- a/Dropdown
+++ b/Dropdown
@@ -260,20 +260,21 @@ const ImageFetcher = {
         const themeQuery = document.getElementById('activity-container').dataset.queryTheme;
         if (!container || !themeQuery) return;
 
-        const url = `https://api.pexels.com/v1/search?query=${encodeURIComponent(themeQuery)}&per_page=1&orientation=landscape`;
-        await this.fetchAndApply(url, container, themeQuery);
+        const keywords = themeQuery.trim().split(/\s+/).slice(0,3).join(' ');
+        const url = `https://api.bing.microsoft.com/v7.0/images/search?q=${encodeURIComponent(keywords)}&count=1&license=public&safeSearch=Strict`;
+        await this.fetchAndApply(url, container, keywords);
     },
     async fetchAndApply(url, container, queryForAlt) {
          try {
-            const response = await fetch(url, { headers: { Authorization: this.API_KEY } });
-            if (!response.ok) throw new Error(`Pexels API error: ${response.statusText}`);
+            const response = await fetch(url, { headers: { "Ocp-Apim-Subscription-Key": this.API_KEY } });
+            if (!response.ok) throw new Error(`Bing API error: ${response.statusText}`);
             const data = await response.json();
-            const photo = data.photos[0];
+            const photo = data.value && data.value[0];
 
             if (photo) {
                 const img = document.createElement('img');
-                img.src = photo.src.landscape;
-                img.alt = photo.alt || `Decorative image related to ${queryForAlt}`;
+                img.src = photo.contentUrl;
+                img.alt = photo.name || `Decorative image related to ${queryForAlt}`;
                 img.onload = () => {
                     container.innerHTML = '';
                     container.appendChild(img);

--- a/Grouping
+++ b/Grouping
@@ -229,8 +229,9 @@ const ImageFetcher = {
         const themeQuery = document.getElementById('activity-container').dataset.queryTheme;
         if (!container || !themeQuery) return;
         
-        const url = `https://api.pexels.com/v1/search?query=${encodeURIComponent(themeQuery)}&per_page=1&orientation=landscape`;
-        await this.fetchAndApply(url, container, themeQuery);
+        const keywords = themeQuery.trim().split(/\s+/).slice(0,3).join(' ');
+        const url = `https://api.bing.microsoft.com/v7.0/images/search?q=${encodeURIComponent(keywords)}&count=1&license=public&safeSearch=Strict`;
+        await this.fetchAndApply(url, container, keywords);
     },
 
     // --- MODE 2: IMAGE PER ITEM ---
@@ -240,8 +241,9 @@ const ImageFetcher = {
             const keyword = item.dataset.keyword;
             const imageContainer = item.querySelector('.dnd-item-image-container');
             if (keyword && imageContainer) {
-                const url = `https://api.pexels.com/v1/search?query=${encodeURIComponent(keyword)}&per_page=1&orientation=squarish`;
-                this.fetchAndApply(url, imageContainer, keyword);
+                const kw = keyword.trim().split(/\s+/).slice(0,3).join(' ');
+                const url = `https://api.bing.microsoft.com/v7.0/images/search?q=${encodeURIComponent(kw)}&count=1&license=public&safeSearch=Strict`;
+                this.fetchAndApply(url, imageContainer, kw);
             }
         });
     },
@@ -249,15 +251,15 @@ const ImageFetcher = {
     // --- SHARED FETCH LOGIC ---
     async fetchAndApply(url, container, queryForAlt) {
          try {
-            const response = await fetch(url, { headers: { Authorization: this.API_KEY } });
-            if (!response.ok) throw new Error(`Pexels API error: ${response.statusText}`);
+            const response = await fetch(url, { headers: { "Ocp-Apim-Subscription-Key": this.API_KEY } });
+            if (!response.ok) throw new Error(`Bing API error: ${response.statusText}`);
             const data = await response.json();
-            const photo = data.photos[0];
+            const photo = data.value && data.value[0];
 
             if (photo) {
                 const img = document.createElement('img');
-                img.src = photo.src.landscape; // Use a suitable size like 'landscape' or 'large'
-                img.alt = photo.alt || `Decorative image related to ${queryForAlt}`;
+                img.src = photo.contentUrl; // Use a suitable size like 'landscape' or 'large'
+                img.alt = photo.name || `Decorative image related to ${queryForAlt}`;
                 img.onload = () => {
                     container.innerHTML = ''; 
                     container.appendChild(img);

--- a/Image labelling
+++ b/Image labelling
@@ -406,22 +406,24 @@ const Activity = {
   async fetchImages() {
     const apiKey = 'xgmzSrq1PBV9ELvW4mSlyq6vAf0k6qDrrMd1zIpLrIheWepQ32zN4iJk';
     const imageElements = this.dom.activityContainer.querySelectorAll('img[data-query]');
-    
+
     for (const img of imageElements) {
         const query = img.dataset.query;
-        const url = `https://api.pexels.com/v1/search?query=${encodeURIComponent(query)}&per_page=1`;
-        
+        const keywords = query.trim().split(/\s+/).slice(0,3).join(' ');
+        const url = `https://api.bing.microsoft.com/v7.0/images/search?q=${encodeURIComponent(keywords)}&count=1&license=public&safeSearch=Strict`;
+
         try {
-            const response = await fetch(url, { headers: { Authorization: apiKey } });
-            if (!response.ok) throw new Error(`Pexels API error: ${response.status}`);
+            const response = await fetch(url, { headers: { "Ocp-Apim-Subscription-Key": apiKey } });
+            if (!response.ok) throw new Error(`Bing API error: ${response.status}`);
             const data = await response.json();
-            if (data.photos.length > 0) {
-                img.src = data.photos[0].src.large;
+            if (data.value && data.value.length > 0) {
+                img.src = data.value[0].contentUrl;
+                img.alt = data.value[0].name || `Decorative image for ${keywords}`;
             } else {
-                img.alt = `No image found for '${query}'`;
+                img.alt = `No image found for '${keywords}'`;
             }
         } catch (error) {
-            console.error(`Failed to fetch image for "${query}":`, error);
+            console.error(`Failed to fetch image for "${keywords}":`, error);
             img.alt = 'Image could not be loaded.';
         }
     }

--- a/Linking
+++ b/Linking
@@ -374,19 +374,20 @@ const ImageFetcher = {
         const container = document.getElementById('decorative-image-container');
         const themeQuery = document.getElementById('activity-container').dataset.queryTheme;
         if (!container || !themeQuery) return;
-        const url = `https://api.pexels.com/v1/search?query=${encodeURIComponent(themeQuery)}&per_page=1&orientation=landscape`;
-        await this.fetchAndApply(url, container, themeQuery);
+        const keywords = themeQuery.trim().split(/\s+/).slice(0,3).join(' ');
+        const url = `https://api.bing.microsoft.com/v7.0/images/search?q=${encodeURIComponent(keywords)}&count=1&license=public&safeSearch=Strict`;
+        await this.fetchAndApply(url, container, keywords);
     },
     async fetchAndApply(url, container, queryForAlt) {
          try {
-            const response = await fetch(url, { headers: { Authorization: this.API_KEY } });
-            if (!response.ok) throw new Error(`Pexels API error: ${response.statusText}`);
+            const response = await fetch(url, { headers: { "Ocp-Apim-Subscription-Key": this.API_KEY } });
+            if (!response.ok) throw new Error(`Bing API error: ${response.statusText}`);
             const data = await response.json();
-            const photo = data.photos[0];
+            const photo = data.value && data.value[0];
             if (photo) {
                 const img = document.createElement('img');
-                img.src = photo.src.landscape; 
-                img.alt = photo.alt || `Decorative image related to ${queryForAlt}`;
+                img.src = photo.contentUrl;
+                img.alt = photo.name || `Decorative image related to ${queryForAlt}`;
                 img.onload = () => { container.innerHTML = ''; container.appendChild(img); };
                 img.onerror = () => { container.innerHTML = 'X'; };
             } else { container.innerHTML = '?'; }

--- a/Multiple Choice Grid
+++ b/Multiple Choice Grid
@@ -494,27 +494,28 @@ const App = {
 
 const ImageFetcher = {
     API_KEY: 'xgmzSrq1PBV9ELvW4mSlyq6vAf0k6qDrrMd1zIpLrIheWepQ32zN4iJk',
-    
+
     async initSingleImage() {
         const container = document.getElementById('decorative-image-container');
         const themeQuery = document.getElementById('activity-container').dataset.queryTheme;
         if (!container || !themeQuery) return;
-        
-        const url = `https://api.pexels.com/v1/search?query=${encodeURIComponent(themeQuery)}&per_page=1&orientation=landscape`;
-        await this.fetchAndApply(url, container, themeQuery);
+
+        const keywords = themeQuery.trim().split(/\s+/).slice(0,3).join(' ');
+        const url = `https://api.bing.microsoft.com/v7.0/images/search?q=${encodeURIComponent(keywords)}&count=1&license=public&safeSearch=Strict`;
+        await this.fetchAndApply(url, container, keywords);
     },
 
     async fetchAndApply(url, container, queryForAlt) {
          try {
-            const response = await fetch(url, { headers: { Authorization: this.API_KEY } });
-            if (!response.ok) throw new Error(`Pexels API error: ${response.statusText}`);
+            const response = await fetch(url, { headers: { "Ocp-Apim-Subscription-Key": this.API_KEY } });
+            if (!response.ok) throw new Error(`Bing API error: ${response.statusText}`);
             const data = await response.json();
-            const photo = data.photos[0];
+            const photo = data.value && data.value[0];
 
             if (photo) {
                 const img = document.createElement('img');
-                img.src = photo.src.landscape; 
-                img.alt = photo.alt || `Decorative image related to ${queryForAlt}`;
+                img.src = photo.contentUrl;
+                img.alt = photo.name || `Decorative image related to ${queryForAlt}`;
                 img.onload = () => {
                     container.innerHTML = ''; 
                     container.appendChild(img);

--- a/ranking
+++ b/ranking
@@ -268,27 +268,28 @@ const App = {
 
 const ImageFetcher = {
     API_KEY: 'xgmzSrq1PBV9ELvW4mSlyq6vAf0k6qDrrMd1zIpLrIheWepQ32zN4iJk',
-    
+
     async initSingleImage() {
         const container = document.getElementById('decorative-image-container');
         const themeQuery = document.getElementById('activity-container').dataset.queryTheme;
         if (!container || !themeQuery) return;
-        
-        const url = `https://api.pexels.com/v1/search?query=${encodeURIComponent(themeQuery)}&per_page=1&orientation=landscape`;
-        await this.fetchAndApply(url, container, themeQuery);
+
+        const keywords = themeQuery.trim().split(/\s+/).slice(0,3).join(' ');
+        const url = `https://api.bing.microsoft.com/v7.0/images/search?q=${encodeURIComponent(keywords)}&count=1&license=public&safeSearch=Strict`;
+        await this.fetchAndApply(url, container, keywords);
     },
 
     async fetchAndApply(url, container, queryForAlt) {
          try {
-            const response = await fetch(url, { headers: { Authorization: this.API_KEY } });
-            if (!response.ok) throw new Error(`Pexels API error: ${response.statusText}`);
+            const response = await fetch(url, { headers: { "Ocp-Apim-Subscription-Key": this.API_KEY } });
+            if (!response.ok) throw new Error(`Bing API error: ${response.statusText}`);
             const data = await response.json();
-            const photo = data.photos[0];
+            const photo = data.value && data.value[0];
 
             if (photo) {
                 const img = document.createElement('img');
-                img.src = photo.src.landscape; 
-                img.alt = photo.alt || `Decorative image related to ${queryForAlt}`;
+                img.src = photo.contentUrl;
+                img.alt = photo.name || `Decorative image related to ${queryForAlt}`;
                 img.onload = () => {
                     container.innerHTML = ''; 
                     container.appendChild(img);


### PR DESCRIPTION
## Summary
- switch decorative image fetching to Bing's image search across all standalone activities
- limit queries to the first three keywords and request Creative Commons images only
- add alt text when Bing image results are used in image labelling

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6867baf2fe648326a73bd0824e2b8502